### PR TITLE
Pin Node.js 24.x for Vercel (discontinued Node 18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

Vercel builds fail with: `Found invalid or discontinued Node.js Version: "18.x"` and instructs using Node 24.x.

## Changes

- Add `engines.node`: `24.x` in `package.json` so deployments resolve to a supported runtime and stay aligned with [Vercel’s Node version guidance](https://vercel.link/node-version).

## Notes

If the project still has Node 18 selected under **Project → Settings → General → Node.js Version**, update it to **24.x** to match.
